### PR TITLE
v0.2.6:   support $_field_primary_key,  and $_enable_delete_all 

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,19 +204,14 @@ class DbTable {
     /*
     * usage: new DbTable(<String:tablename>, <Dbc:db_connection>)
     *        new DbTable(<Dbc:db_connection>)
+    * @tablename : <String>    ; optional, default is $classname
+    * @dbc       : <DbcObject> ; required! if undefined try to init from $1:tablename_or_dbc
     * */
     constructor(tablename_or_dbc, dbc) {
-        // $dbc is required, if undefined try to init from $1:tablename_or_dbc
-        dbc = dbc || tablename_or_dbc;
         this._cls = `<DbTable:${this.constructor.name}>`;
-        if (typeof (tablename_or_dbc) === "string") {
-            this.tablename = tablename_or_dbc;
-        } else {
-            this.tablename = this.constructor.name;
-        }
-        if (isDbc(dbc)) {
-            this.dbc = dbc;
-        } else {
+        this.dbc = dbc || tablename_or_dbc;
+        this.tablename = typeof (tablename_or_dbc) === "string" ? tablename_or_dbc : this.constructor.name;
+        if (!isDbc(dbc)) {
             throw new Error(`${this._cls}[${this.tablename}]: init with invalid dbc ...`)
         }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 /*
-*  Mysql Db Table
-*  统一数据库的接口，尽量不要裸写 mysql 语句
+*  Mysql Dbc Table:
+*    A Simple Toolkit for Human to CRUD Table of Mysql.
+*  copyright@https://github.com/dodoru/mysql-dbc-table
 * */
 
 const mysql_dbc = require('mysql-dbc');
@@ -187,8 +188,14 @@ class DbTable {
         return this.toString();
     }
 
+    /*
+    * <fields>: define columns of Mysql Table, require override in SubClass of DbTable
+    * options:
+          `fmt` : <Function> : convert raw data from `node-mysql2` to javascript object.
+          `default` : <value>: optional to init a row object to insert into mysql table.
+    * return: {<$column>: {fmt: <$function>}}
+    * */
     static fields() {
-        // require super in subclass
         return {
             id: {
                 fmt: parseInt,

--- a/index.js
+++ b/index.js
@@ -158,6 +158,47 @@ const dbSqlAsync = async (dbc, sql, args) => {
 
 
 class DbTable {
+    /*
+    * <usage>: define column fields of DbTable, require override in SubClass of DbTable
+    * options:
+      `fmt` : <Function> : convert raw data from `node-mysql2` to javascript object.
+      `default` : <value>: optional to init a row object to insert into mysql table.
+    * return: {<$column>: {fmt: <$function>}}
+    * sample:
+
+        class User extends DbTable {
+            static fields() {
+                return {
+                    id: {fmt: parseInt},
+                    name: {fmt: String, default: ''},
+                    created_time: {fmt: (...args) => new Date(...args)},
+                    deleted: {fmt: Boolean, default: false},
+                }
+            }
+        }
+
+    * @_field_flag_hidden: <String: name of Primary-Column>
+    * @_field_flag_hidden: <String: name of Boolean-Column>
+    *   Table columns should be predefined by $DbTable.fields(), and Note that only One Or Zero field has this flag.
+    *   This flag is designed for #SoftDeletion and #DisplayAfterReview,
+    *   it would be automatically set in conditions while query table and hide deprecated rows.
+    *   default: set column `deleted` to mark data to be hidden in common queries with default arguments.
+    * */
+    static fields() {
+        this._field_primary_key = "id";
+        this._field_flag_hidden = "deleted";
+        return {
+            id: {
+                fmt: parseInt,
+                default: 0,
+            },
+            deleted: {
+                fmt: Boolean,
+                default: false,
+            },
+        }
+    }
+
     constructor(tablename_or_dbc, dbc) {
         // $dbc is required, if undefined try to init from $1:tablename_or_dbc
         dbc = dbc || tablename_or_dbc;
@@ -190,26 +231,6 @@ class DbTable {
     /* support JSON.stringify() */
     toJSON() {
         return this.toString();
-    }
-
-    /*
-    * <usage>: define column fields of DbTable, require override in SubClass of DbTable
-    * options:
-          `fmt` : <Function> : convert raw data from `node-mysql2` to javascript object.
-          `default` : <value>: optional to init a row object to insert into mysql table.
-    * return: {<$column>: {fmt: <$function>}}
-    * */
-    static fields() {
-        return {
-            id: {
-                fmt: parseInt,
-                default: 0,
-            },
-            deleted: {
-                fmt: Boolean,
-                default: false,
-            },
-        }
     }
 
     /*

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@
 
 const mysql_dbc = require('mysql-dbc');
 
-const DbcName = 'mysql-dbc';
-
 const initDbc = (config = {}) => {
     const cfg = {
         // required
@@ -22,7 +20,7 @@ const initDbc = (config = {}) => {
     };
 
     const dbc = mysql_dbc.createDbc();
-    dbc._cls = DbcName;
+    dbc._cls = `<MysqlDbc:${cfg.database}>`;
     dbc.init(cfg);
     dbc.config = cfg;
     dbc.uri = `mysql://${cfg.user}:${cfg.password}@${cfg.host}:${cfg.port}/${cfg.database}`;
@@ -160,14 +158,19 @@ const dbSqlAsync = async (dbc, sql, args) => {
 
 
 class DbTable {
-    constructor(tablename, dbc) {
-        this._cls = this.constructor.name;
-        this.tablename = tablename;
-        if (dbc && dbc instanceof Object && dbc._cls === DbcName) {
-            // todo: 更严谨的判定
+    constructor(tablename_or_dbc, dbc) {
+        // $dbc is required, if undefined try to init from $1:tablename_or_dbc
+        dbc = dbc || tablename_or_dbc;
+        this._cls = `<DbTable:${this.constructor.name}>`;
+        if (typeof (tablename_or_dbc) === "string") {
+            this.tablename = tablename_or_dbc;
+        } else {
+            this.tablename = this.constructor.name;
+        }
+        if (dbc instanceof Object && String(dbc.uri).startsWith("mysql://")) {
             this.dbc = dbc;
         } else {
-            throw new Error(`[DbTable:${this._cls}:${tablename}], init DbTable with invalid dbc ...`)
+            throw new Error(`${this._cls}: init [${this.tablename}] with invalid dbc ...`)
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -344,15 +344,21 @@ class DbTable {
         return form;
     }
 
-    static queryForm(filter, ensureNotDeleted) {
-        const form = Object.assign({}, filter);
-        const fields = this.fields();
-        if ('deleted' in fields) {
-            if (ensureNotDeleted === undefined || ensureNotDeleted) {
-                form.deleted = false;
-            }
+    /*
+    * @opts_eq          : <Object : {$Column_field: $formatted_value}>
+    *                   ; condition to filter with equal fields value
+    *                   ; suggest to use result of $strictForm
+    * @ensureNotDeleted : <Boolean: default(true)>
+    *                   ; hide deprecated items which were soft deleted by `disableAsync()`
+    * */
+    static queryForm(opts_eq = {}, ensureNotDeleted = true) {
+        if (typeof (opts_eq) !== "object") {
+            throw Error(`<DbTable:${this.name}>: invalid $query=${opts_eq}, require <Object>`);
         }
-        return form;
+        if (this._field_flag_hidden && ensureNotDeleted) {
+            opts_eq[this._field_flag_hidden] = false;
+        }
+        return opts_eq;
     }
 
     static equal(a, b) {

--- a/index.js
+++ b/index.js
@@ -352,10 +352,14 @@ class DbTable {
     }
 
     async queryAsync(qry = {}) {
-        const res = qry.res || '*';
         const opts = qry.opts || {};
         const order = qry.order || {};
         const limit = qry.limit;
+        let res = qry.res || '*';
+        if (res === "*") {
+            let fds = this.constructor.fields();
+            res = Object.keys(fds).join(",");
+        }
         const {dbc, tablename} = this;
         const {query, args} = sqlFormat(opts, order, limit);
         const sql = `SELECT ${res} FROM ${tablename} ${query}; `;

--- a/index.js
+++ b/index.js
@@ -216,9 +216,9 @@ class DbTable {
         }
 
         // checkout predefined fields
+        this.fields = this.constructor.fields();
         this._field_primary_key = this.constructor._field_primary_key || "";
         this._field_flag_hidden = this.constructor._field_flag_hidden || "";
-        this.fields = this.constructor.fields();
         if (this._field_flag_hidden) {
             let fg = this.fields[this._field_flag_hidden];
             if (!fg) {

--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ class DbTable {
         if (dbc instanceof Object && String(dbc.uri).startsWith("mysql://")) {
             this.dbc = dbc;
         } else {
-            throw new Error(`${this._cls}: init [${this.tablename}] with invalid dbc ...`)
+            throw new Error(`${this._cls}[${this.tablename}]: init with invalid dbc ...`)
         }
     }
 
@@ -261,7 +261,7 @@ class DbTable {
         for (let column_name of column_names) {
             const is_existed = fields_set.has(column_name);
             if (!is_existed) {
-                throw new Error(`DbTable<${this._cls}> unknown field "${column_name}"`);
+                throw new Error(`${this._cls}[${this.tablename}] unknown field "${column_name}"`);
             }
         }
     }
@@ -562,7 +562,7 @@ class DbTable {
         if (objects instanceof Array) {
             const count = objects.length;
             if (count === 0) {
-                throw new Error(`DbTable<${this._cls}>: no objects to update`)
+                throw new Error(`${this._cls}[${this.tablename}]: no objects to update`)
             }
 
             if (strict) {
@@ -582,7 +582,7 @@ class DbTable {
             result.op = 'replace_into';
             return result;
         } else {
-            throw new Error(`DbTable<${this._cls}>: objects is not instanceof Array`);
+            throw new Error(`${this._cls}[${this.tablename}]: objects is not instanceof Array`);
         }
     }
 
@@ -601,14 +601,14 @@ class DbTable {
         const dup_form = Object.assign({}, duplicate_update);
         const key = dup_form.key;
         if (!key) {
-            throw new Error(`DbTable<${this._cls}>: invalid duplicate_update(${JSON.stringify(duplicate_update)})`)
+            throw new Error(`${this._cls}[${this.tablename}]: invalid duplicate_update(${JSON.stringify(duplicate_update)})`)
         }
         await this.ensureColumnsAsync(key);
 
         if (objects instanceof Array) {
             const count = objects.length;
             if (count === 0) {
-                throw new Error(`DbTable<${this._cls}>: no objects to upsert`)
+                throw new Error(`${this._cls}[${this.tablename}]: no objects to upsert`)
             }
 
             if (strict) {
@@ -635,7 +635,7 @@ class DbTable {
             result.op = 'insert_ondup';
             return result;
         } else {
-            throw new Error(`DbTable<${this._cls}>: objects is not instanceof Array`);
+            throw new Error(`${this._cls}[${this.tablename}]: objects is not instanceof Array`);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -80,8 +80,7 @@ const dbcPool = {
     },
     getPool: () => {
         return dbcPool._pools;
-    }
-
+    },
 };
 
 
@@ -179,17 +178,19 @@ class DbTable {
         return {model, tablename, database, host, port, user}
     }
 
+    /* support String() */
     toString() {
         const {model, tablename, database, host, port, user} = this.info();
         return `[DbTable:${model}:${tablename}] dbc=${user}@${host}:${port}/${database}`;
     }
 
+    /* support JSON.stringify() */
     toJSON() {
         return this.toString();
     }
 
     /*
-    * <fields>: define columns of Mysql Table, require override in SubClass of DbTable
+    * <usage>: define column fields of DbTable, require override in SubClass of DbTable
     * options:
           `fmt` : <Function> : convert raw data from `node-mysql2` to javascript object.
           `default` : <value>: optional to init a row object to insert into mysql table.
@@ -208,10 +209,10 @@ class DbTable {
         }
     }
 
-    async showColumnsAsync() {
-        /*
-         samples of rows and cols
-         col = {
+    /*
+    * <usage>: show column fields of Mysql Table
+    * sample item of <List:$cols> and <List:$rows> from results of sql query.
+     col = {
             catalog: 'def',
             schema: 'information_schema',
             name: 'Field',
@@ -223,16 +224,18 @@ class DbTable {
             columnType: 253,
             flags: 1,
             decimals: 0
-         },
-         row = TextRow {
+     }
+     row = TextRow {
             Field: 'id',
             Type: 'int(11)',
             Null: 'NO',
             Key: 'PRI',
             Default: null,
             Extra: 'auto_increment'
-         },
-        * */
+     }
+    * return: <List: [ <Object:{Field, Type, Key, Default, Extra}> ] >
+    * */
+    async showColumnsAsync() {
         const dbc = this.dbc;
         const tablename = this.tablename;
         const sql = `show columns from ${tablename}`;
@@ -241,6 +244,9 @@ class DbTable {
         return rows;
     }
 
+    /*
+    * return: <List: [ <String:$ColumnName> ]>
+    * */
     async listColumnNamesAsync() {
         const columns = await this.showColumnsAsync();
         return columns.map(m => m.Field);

--- a/index.js
+++ b/index.js
@@ -432,13 +432,10 @@ class DbTable {
         return obj;
     }
 
-    async findLimitAsync(limit = 1, filter = {}, order = {}, ensureNotDeleted) {
-        // size: int : 个数
-        const {dbc, tablename} = this;
+    async findLimitAsync(limit = 1, filter = {}, order = {}, ensureNotDeleted, res = "*") {
         const form = this.constructor.queryForm(filter, ensureNotDeleted);
-        const {query, args} = sqlFormat({eq: form}, order, limit);
-        const sql = `SELECT * from ${tablename} ${query} ;`;
-        return await this.selectAsync(sql, args);
+        const cond = {limit, order, res, opts: {eq: form}};
+        return await this.queryAsync(cond);
     }
 
     async findOneByFieldsAsync(field_keys, field_values) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mysql-dbc-table",
-  "version": "0.0.7",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mysql-dbc-table",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "creating and manipulating MySQL table by inheriting parent class<DbTable> with mysl-dbc",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -1,45 +1,66 @@
 
 # mysql-dbc-table
 
-creating and manipulating MySQL table by inheriting parent class<DbTable> with mysl-dbc
+A Simple Toolkit for Human to CRUD Table of Mysql.
+---
 
-### Install
+## Targets • 目标
 
+- Simple Code but Flexible Usage.
+- Restful CRUD Api to query Mysql table. 
+- Fast predefine Column fields of table. (`$DbTable.fields()`)
+- Auto formatted($fmt) sql data to js object.(`$_field_flag_hidden`)
+- Support Soft Deletion and Soft Recovery. (`$_field_flag_hidden`)
+ 
+```text
+1. 代码简单，使用灵活
+2. 接口易用，快速业务CURD
+3. 快速预设表列信息 (`$DbTable.fields()`)
+4. 自动格式转化sql查询结果为 js 常用对象 (`$fmt`)
+5. 支持软删除, 软回收 (`$_field_flag_hidden`)
+```
+
+## Install • 安装
 ```shell
 npm install mysql-dbc-table
 ```
 
+## Depends • 依赖
 
-### Usage Sample
+- [sidorares/node-mysql2](https://github.com/sidorares/node-mysql2)
+- [physacco/node-mysql-dbc](https://github.com/physacco/node-mysql-dbc)
 
-#### Init mysql db connection
+## Samples • 示例
+
+#### 1. Init Dbc: 初始化连接
 
 ```javascript
-
 const mysql_dbc_table = require('./mysql-dbc-table');
+const dbc_default = mysql_dbc_table.initDbc();
+//; dbc_default.uri = "mysql://root:@localhost:3306/test"
 
-// default:  mysql://root:@localhost:3306/test
-const dbc = mysql_dbc_table.initDbc();
-
-// custom: mysql://${user}:${password}@${host}:${port}/${database}
-const dbc1 = mysql_dbc_table.initDbc({
+//; customize dbc with {host,port,user,password,database,connectionLimit,queueLimit} 
+const dbc_custom = mysql_dbc_table.initDbc({
     host: 'localhost',
     port: 3306,
-    user: 'developer',
+    user: 'user',
     password: 'my_password',
     database: 'my_database',
 });
+// dbc_custom.uri = "mysql://${user}:${password}@${host}:${port}/${database}"
 
-```
+//; list tables of database
+dbc_custom.showTablesAsync()
+````
 
-#### Perform SQL
+#### 2. execute sql:执行原始MySQL语句
 
 ```javascript
-
 const sql_create_table = `
     CREATE TABLE \`user\` (
       \`id\` int(11) NOT NULL AUTO_INCREMENT,
       \`name\` varchar(64) NOT NULL,
+      \`city\` varchar(64) NOT NULL,
       \`created_time\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
       \`modified_time\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
       \`deleted\` boolean DEFAULT false,
@@ -47,30 +68,82 @@ const sql_create_table = `
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 `;
 
-const step0 = await mysql_dbc_table.dbSqlAsync(dbc, sql_create_table);
-
+dbc_custom.executeSqlAsync(sql_create_table);
 ```
 
-#### Use data model with DbTable
-```
+#### 2. predefine Table and CRUD: 预设表列和CURD
+
+```javascript
 const DbTable = mysql_dbc_table.DbTable;
+
 class User extends DbTable {
     static fields() {
+        this._field_flag_hidden = "deleted";        
         return {
             id: {fmt: parseInt},
             name: {fmt: String, default: ''},
+            city: {fmt: String, default: ''},
             created_time: {fmt: (...args) => new Date(...args)},
             modified_time: {fmt: (...args) => new Date(...args)},
-            deleted: {fmt: Boolean, default: false},
+            deleted : {fmt: Boolean, default: false},
         }
     }
 }
 
-const db_user = new User('user', dbc);
-const existed = await db_user.existAsync();
+const test_crud = async () => {
+    // 0. init: 初始化
+    // get instance of <DbTable:User> and check table exist
+    const db_user = new User("user", dbc_custom);
+    let is_existed = await db_user.existAsync();
+    if (!is_existed) {
+        // !require manually create table if not existed
+        let res = await dbc_custom.executeSqlAsync(sql_create_table);
+        is_existed = await db_user.existAsync();
+    }
+    
 
-const users = await db_user.findAsync();
-const user = await db_user.findOneAsync();
+    // 1. create: 添加
+    // insert one object
+    const uid1 = await db_user.addAsync({name: 'usr1', city: 'A'});
+    // insert many objects
+    await db_user.addManyAsync([{name:'usr2', city: 'B'}, {name:'usr3', city: 'B'}]);
+    
+
+    // 2. read: 读取
+    // real columns of mysql table 
+    const columns = await db_user.showColumnsAsync()
+
+    // following query results without deleted user if $_field_flag_hidden was set.
+    // count rows
+    const total = await db_user.countAsync();
+    const count = await db_user.countAsync({city:'B'});
+    // get one or raise 404
+    const u0 = await db_user.getOr404Async({id:uid1});
+    // get one or null
+    const u1 = await db_user.getOrNullAsync({id:uid1});
+    // support compare with predefined fields
+    User.equal(u0, u1);          // ==> True
+    // first or null
+    const u2 = await db_user.findOneAsync({city: 'B'});
+    // list with conditions
+    const us1 = await db_user.findAsync({city: 'B'});
+    // list all  
+    const us2 = await db_user.findAsync();
+    
+    
+    // 3. update : 修改
+    // DbTable.updateAsync(conditions, updated_form) 
+    db_user.updateAsync({id:uid}, {name:"Ein"})
+    // soft deletion, it will hidden User<id:$uid> if redo previous query. 
+    db_user.disableAsync({id:uid})
+    // soft recovery,  User<id:$uid>
+    db_user.enableAsync({id:uid})    
+    
+
+    // 4. delete : 删除 
+    // hard deletion, never recovery by DbTable
+    db_user.deleteAsync({id:uid})
+    // !!! dangerous：delete all rows of table.
+    db_user.deleteAsync()    // raise Exception to protect table
+}
 ```
-
-##### 更多请参阅 test.js


### PR DESCRIPTION
1.  better readme and  note for most common CRUD apis.
2.  better #softDeletion and #softRecovery  with $_field_flag_hidden
3.  avoid to delete all rows with $_enable_delete_all
4.  better performance to `countAsync` with $_field_primary_key
5.  [API-D]  remove api: `DbTable.findLimitAsync()`
6.  [API-A]  add api: `DbTable.getOrNullAsync()`